### PR TITLE
Fix: respected new_file_name when file_location is used in upload.

### DIFF
--- a/lib/Backblaze/B2V2Client.pm
+++ b/lib/Backblaze/B2V2Client.pm
@@ -180,7 +180,7 @@ sub b2_upload_file {
 		$args{file_contents} = path( $args{file_location} )->slurp_raw;
 		
 		# if they didn't provide a file-name, use the one on this file
-		$args{new_file_name} = path( $args{file_location} )->basename;
+		$args{new_file_name} //= path( $args{file_location} )->basename;
 	}
 	
 	# were these file contents either provided or found?


### PR DESCRIPTION
Issue #2: When uploading a file, 'new_file_name' is ignored when a
file location (rather than content) is specified using 'file_location'.
This fix allows this to now happen.